### PR TITLE
Fix `doc:view` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "jest --watch",
     "ci": "npm run lint && jest",
     "doc": "jsdoc -c .jsdoc src/*.js",
-    "doc:view": "serve -s dist/doc",
+    "doc:view": "serve dist/doc",
     "doc:watch": "nodemon --exec \"npm run doc\" --watch src --watch ./ --ext js,md --ignore dist",
     "doc:live": "run-p doc:watch doc:view",
     "lint": "eslint src webpack.*",


### PR DESCRIPTION
While reviewing https://github.com/jeremyckahn/shifty/pull/135, I noticed a pre-existing bug that was breaking local documentation testing. This isn't a bug that resulted from https://github.com/jeremyckahn/shifty/pull/135, that PR simply made me notice the bug and will help with reviewing it!

To test this yourself, you can run `npm run doc && npm run doc:view` and navigate to the URL printed in your terminal. From there, the API links should now be working (they weren't before this change).